### PR TITLE
Make whitelist hook configurable

### DIFF
--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -29,7 +29,7 @@ def load_jupyter_server_extension(nbapp):
     nbapp.web_app.add_handlers('.*', server_handlers)
 
     # Set up default handler
-    setup_handlers(nbapp.web_app)
+    setup_handlers(nbapp.web_app, serverproxy.host_whitelist_hook)
 
     launcher_entries = []
     icons = {}

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -2,7 +2,7 @@
 Traitlets based configuration for jupyter_server_proxy
 """
 from notebook.utils import url_path_join as ujoin
-from traitlets import Dict
+from traitlets import Any, Dict
 from traitlets.config import Configurable
 from .handlers import SuperviseAndProxyHandler, AddSlashHandler
 import pkg_resources
@@ -160,5 +160,27 @@ class ServerProxy(Configurable):
             title
               Title to be used for the launcher entry. Defaults to the name of the server if missing.
         """,
+        config=True
+    )
+
+    host_whitelist_hook = Any(
+        lambda handler, host: host in ['localhost', '127.0.0.1'],
+        help="""
+        Verify that a host should be proxied.
+
+        This should be a callable that checks whether a host should be proxied
+        and returns True if so (False otherwise).  It could be a very simple
+        check that the host is present in a list of allowed hosts, or it could
+        be a more complex verification against a regular expression.  It should
+        probably not be a slow check against an external service.  Here is an 
+        example that could be placed in a site-wide Jupyter notebook config:
+
+            def hook(handler, host):
+                handler.log.info("Request to proxy to host " + host)
+                return host.startswith("10.")
+            c.ServerProxy.host_whitelist_hook = hook
+        
+        The default check is to return True if the host is localhost.
+        """, 
         config=True
     )

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -43,6 +43,8 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     def __init__(self, *args, **kwargs):
         self.proxy_base = ''
         self.absolute_url = kwargs.pop('absolute_url', False)
+        self.host_whitelist_hook = kwargs.pop('host_whitelist_hook',
+                lambda handler, host: host in ['localhost', '127.0.0.1'])
         super().__init__(*args, **kwargs)
 
     # Support all the methods that torando does by default except for GET which
@@ -168,9 +170,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         return req
 
     def _check_host_whitelist(self, host):
-        # TODO Get whitelist from config
-        whitelist = [r'localhost', r'127\.0\.0\.1']
-        return any([bool(re.match(pattern, host)) for pattern in whitelist])
+        return self.host_whitelist_hook(self, host)
 
     @web.authenticated
     async def proxy(self, host, port, proxied_path):
@@ -521,7 +521,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         return self.proxy(self.port, path)
 
 
-def setup_handlers(web_app):
+def setup_handlers(web_app, host_whitelist_hook):
     host_pattern = '.*$'
     web_app.add_handlers('.*', [
         (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'),
@@ -529,9 +529,9 @@ def setup_handlers(web_app):
         (url_path_join(web_app.settings['base_url'], r'/proxy/absolute/(\d+)(.*)'),
          LocalProxyHandler, {'absolute_url': True}),
         (url_path_join(web_app.settings['base_url'], r'/proxy/(.*):(\d+)(.*)'),
-         RemoteProxyHandler, {'absolute_url': False}),
+         RemoteProxyHandler, {'absolute_url': False, 'host_whitelist_hook': host_whitelist_hook}),
         (url_path_join(web_app.settings['base_url'], r'/proxy/absolute/(.*):(\d+)(.*)'),
-         RemoteProxyHandler, {'absolute_url': True}),
+         RemoteProxyHandler, {'absolute_url': True, 'host_whitelist_hook': host_whitelist_hook}),
     ])
 
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
Here's a commit to make the whitelist hook configurable.  I left your `_check_host_whitelist` function in place in case you think it might be wise to wrapper the call with a check to ensure the method is callable or exists or whatnot.  This may not be necessary as we've set the default to be to check that the host is either `localhost` or loopback by default.